### PR TITLE
Fix package installation with install_github()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,3 +14,5 @@ Imports:
     RODBC
 Suggests: 
     testthat
+Remotes:
+    github::vh-d/r2r


### PR DESCRIPTION
Add "Remotes" section to DESCRIPTION so that `remotes::install_github()` can install the dependent package r2r automatically. 
See https://remotes.r-lib.org/#dependencies-on-github